### PR TITLE
Various updates to improve logging and dropped alerts

### DIFF
--- a/internal/findings/mappings.go
+++ b/internal/findings/mappings.go
@@ -19,6 +19,7 @@ func InitMap() map[string]string {
 	eventMap["NewExternalClientDns"] = TtpInitialAccess
 	eventMap["NewExternalClientConn"] = TtpInitialAccess
 	eventMap["NewExternalClientBadIpConn"] = UnusualIP
+	eventMap["ExternalClientBadIpConn"] = UnusualIP
 	eventMap["NewExternalClientBadIp"] = UnusualIP
 	eventMap["NewExternalClientBadDns"] = UnusualIP
 	eventMap["NewInternalServerIP"] = TtpInitialAccess

--- a/main.go
+++ b/main.go
@@ -88,7 +88,7 @@ func handler(ctx context.Context, e events.SQSEvent) {
 				fmt.Println("ERROR: while creating aws session: ", err)
 			}
 			svc := securityhub.New(sess)
-			fmt.Printf("%+v\n", batch.Findings)
+			fmt.Printf("%+v", batch.Findings)
 			//fmt.Printf("Sending %d finding(s) to Security Hub\n", len(batch.Findings))
 			output, err := svc.BatchImportFindings(&batch)
 			if err != nil {


### PR DESCRIPTION
- Added missing alert type (ExternalClientBadIpConn) to mapping file
- Modified logging to print full payload struct in one CloudWatch logline
- Added function to **internal/findings/aws.go** to limit the number of properties added to Details.Other so that findings adhere to the Amazon Finding Format and resolve issues with this error message:

```
'ErrorMessage': 'Finding does not adhere to Amazon Finding Format. data.Resources[0].Details.Other should NOT have more than 50 properties, 
data.Resources[0].Details should pass "$merge" keyword validation.'}]}
```