### PR TITLE
Revert "Update mappings.go"

### DIFF
--- a/internal/findings/mappings.go
+++ b/internal/findings/mappings.go
@@ -85,7 +85,7 @@ func InitMap() map[string]string {
 	eventMap["CustomerMasterKeyScheduledForDeletion"] = TtpCredential
 	eventMap["SuccessfulConsoleLoginWithoutMFA"] = TtpCredential
 	eventMap["FailedConsoleLogin"] = TtpCredential
-	eventMap["Usage of Root Account"] = TtpPrivilege
+	eventMap["UsageOfRootAccount"] = TtpPrivilege
 	eventMap["UnauthorizedAPICall"] = TtpCredential
 	eventMap["ConfigServiceChange"] = TtpDiscovery
 	eventMap["CloudTrailDefaultAlert"] = TtpCollection


### PR DESCRIPTION
Reverts lacework-alliances/aws-security-hub-integration#16

The initial value was correct for prod Lacework instances. 