### PR TITLE
26 composite alerts are dropped because they dont they dont have a type defined in mappingsgo

### DIFF
--- a/internal/findings/findings.go
+++ b/internal/findings/findings.go
@@ -27,6 +27,7 @@ const (
 	SoftwareCVE           = "Software and Configuration Checks/Vulnerabilities/CVE"
 	SoftwarePolicy        = "Software and Configuration Checks/Policy"
 	AWSCompliance         = "Software and Configuration Checks/Industry and Regulatory Standards/CIS AWS Foundations Benchmark"
+	TtpComposite          = "TTPs/Unusual Behaviors"
 
 	ArnFormat = "arn:aws:securityhub:%s::product/lacework/lacework"
 

--- a/internal/findings/findings.go
+++ b/internal/findings/findings.go
@@ -84,13 +84,20 @@ func mapDefault(ctx context.Context, le types.LaceworkEvent) securityhub.AwsSecu
 	} else {
 		desc = le.Detail.Summary
 	}
+
+	checkForEmptyTypes := getTypes(cfg.EventMap, le.Detail.EventType)
+	if len(checkForEmptyTypes) == 1 && aws.StringValue(checkForEmptyTypes[0]) == "" {
+		checkForEmptyTypes = []*string{aws.String("Uncategorized/GeneralFinding")} // Default value for missing mype in mappings.go
+		fmt.Printf("Unknown EvnetType: %s\n", le.Detail.EventType)
+	}
+	
 	finding := securityhub.AwsSecurityFinding{
 		AwsAccountId:  aws.String(getAwsAccount(cfg.DefaultAccount, le.Detail.Summary)),
 		GeneratorId:   aws.String(le.Detail.EventCategory),
 		SchemaVersion: aws.String(SCHEMA),
 		Id:            aws.String(le.ID),
 		ProductArn:    getProductArn(cfg.Region),
-		Types:         getTypes(cfg.EventMap, le.Detail.EventType),
+		Types:         checkForEmptyTypes,
 		CreatedAt:     aws.String(le.Time.Format(time.RFC3339)),
 		UpdatedAt:     aws.String(le.Time.Format(time.RFC3339)),
 		Severity:      getSeverity(le.Detail.Severity),

--- a/internal/findings/mappings.go
+++ b/internal/findings/mappings.go
@@ -5,6 +5,13 @@ func InitMap() map[string]string {
 	// map[EVENT_TYPE]SEC_HUB_TYPE{}
 	var eventMap = map[string]string{}
 
+	eventMap["PotentialPenetrationTest"] = TtpComposite
+	eventMap["PotentiallyCompromisedAwsCredentials"] = TtpComposite
+	eventMap["PotentiallyCompromisedHost"] = TtpComposite
+	eventMap["PotentiallyCompromisedAzure"] = TtpComposite
+	eventMap["PotentiallyCompromisedGCP"] = TtpComposite
+	eventMap["PotentiallyCompromisedK8s"] = TtpComposite
+	
 	eventMap["NewExternalServerDns"] = TtpInitialAccess
 	eventMap["NewExternalServerIp"] = TtpInitialAccess
 	eventMap["NewExternalDnsServer"] = TtpInitialAccess


### PR DESCRIPTION
Made the following changes:

1. Added all composite alert EventTypes to mappings.go,
2. Added a default Type of "Uncategorized/GeneralFinding" to any alert that doesn't have a corresponding EventType/Type in mappings.go