### PR TITLE
30 add specific handling for composite alerts using supporting facts

### DIFF
--- a/internal/findings/composite.go
+++ b/internal/findings/composite.go
@@ -1,0 +1,80 @@
+package findings
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/securityhub"
+	"github.com/lacework-alliances/aws-security-hub-integration/pkg/types"
+	"time"
+)
+
+type Composite struct {
+	Event  types.LaceworkEvent
+	config types.Config
+}
+
+func (c Composite) Findings(ctx context.Context) []*securityhub.AwsSecurityFinding {
+	var fs []*securityhub.AwsSecurityFinding
+	// format the finding description
+	desc := getDescription(c.Event.Detail.Summary)
+	// grab the config struct from the context
+	c.config = ctx.Value("config").(types.Config)
+	for _, e := range c.Event.Detail.EventDetails.Data {
+		generatorID := c.Event.Detail.EventCategory
+		finding := securityhub.AwsSecurityFinding{
+			AwsAccountId:  aws.String(c.config.DefaultAccount),
+			GeneratorId:   aws.String(generatorID),
+			SchemaVersion: aws.String(SCHEMA),
+			Id:            aws.String(c.Event.ID),
+			ProductArn:    getProductArn(c.config.Region),
+			Types:         getTypes(c.config.EventMap, c.Event.Detail.EventType),
+			CreatedAt:     aws.String(c.Event.Time.Format(time.RFC3339)),
+			UpdatedAt:     aws.String(c.Event.Time.Format(time.RFC3339)),
+			Severity:      getSeverity(c.Event.Detail.Severity),
+			Title:         aws.String(desc),
+			Description:   aws.String(c.Event.Detail.Summary),
+			SourceUrl:     aws.String(c.Event.Detail.Link),
+			Resources:     c.resource(e),
+		}
+		fs = append(fs, &finding)
+	}
+	return fs
+}
+
+func (c Composite) resource(data types.Data) []*securityhub.Resource {
+	var resourceList []*securityhub.Resource
+	var res securityhub.Resource
+	// create resource of supporting facts
+	res = securityhub.Resource{
+		Details: &securityhub.ResourceDetails{},
+		Type:    aws.String("Other"),
+	}
+	res.Id, res.Details.Other = c.otherDetails(data)
+	resourceList = append(resourceList, &res)
+	return resourceList
+}
+
+func (c Composite) otherDetails(data types.Data) (*string, map[string]*string) {
+	otherMap := make(map[string]*string)
+	var id *string
+
+	d := fmt.Sprintf("%s-%s", data.EventModel, data.EventType)
+	if len(d) > 64 {
+		id = aws.String(d[:64])
+	} else {
+		id = aws.String(d)
+	}
+	// Supporting facts are used to describe alert rather than specific resources involved
+	// AWS requires that values in OtherDetails are less than 1024 characters
+	for i, fact := range c.Event.Detail.SupportingFacts {
+		text := fact.Text
+		if len(text) > 1024 {
+			text = fact.Text[:1024]
+		}
+		key := fmt.Sprintf("Fact-%d", i)
+		otherMap[key] = aws.String(text)
+	}
+
+	return id, otherMap
+}

--- a/internal/findings/findings.go
+++ b/internal/findings/findings.go
@@ -39,6 +39,10 @@ func EventToASFF(ctx context.Context, le types.LaceworkEvent) []*securityhub.Aws
 	var category string
 	// get the category to determine finding
 	category = le.Detail.EventCategory
+	// check to see if this is a composite alert
+	if le.Detail.Source == "LWComposite" {
+		category = "Composite"
+	}
 	switch category {
 	case "App":
 		fmt.Println("source is App")
@@ -54,6 +58,11 @@ func EventToASFF(ctx context.Context, le types.LaceworkEvent) []*securityhub.Aws
 		fmt.Println("source is AWS")
 		a := Aws{Event: le}
 		findings := a.Findings(ctx)
+		fs = append(fs, findings...)
+	case "Composite":
+		fmt.Println("source is Composite")
+		compos := Composite{Event: le}
+		findings := compos.Findings(ctx)
 		fs = append(fs, findings...)
 	case "GcpAuditTrail":
 		finding := mapDefault(ctx, le)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -241,17 +241,22 @@ type EventDetails struct {
 }
 
 type Detail struct {
-	EventID       string       `json:"EVENT_ID"`
-	EventName     string       `json:"EVENT_NAME"`
-	EventType     string       `json:"EVENT_TYPE"`
-	Summary       string       `json:"SUMMARY"`
-	StartTime     string       `json:"START_TIME"`
-	EventCategory string       `json:"EVENT_CATEGORY"`
-	Link          string       `json:"LINK"`
-	EventDetails  EventDetails `json:"EVENT_DETAILS"`
-	Severity      int          `json:"SEVERITY"`
-	Account       string       `json:"ACCOUNT"`
-	Source        string       `json:"SOURCE"`
+	EventID         string           `json:"EVENT_ID"`
+	EventName       string           `json:"EVENT_NAME"`
+	EventType       string           `json:"EVENT_TYPE"`
+	Summary         string           `json:"SUMMARY"`
+	StartTime       string           `json:"START_TIME"`
+	EventCategory   string           `json:"EVENT_CATEGORY"`
+	Link            string           `json:"LINK"`
+	EventDetails    EventDetails     `json:"EVENT_DETAILS"`
+	Severity        int              `json:"SEVERITY"`
+	Account         string           `json:"ACCOUNT"`
+	Source          string           `json:"SOURCE"`
+	SupportingFacts []SupportingFact `json:"SUPPORTING_FACTS"`
+}
+
+type SupportingFact struct {
+	Text string `json:"supportingFactText"`
 }
 
 // Honeyvent defines what a Honeycomb event looks like for the AWS Security Hub Integration


### PR DESCRIPTION
Added support for composite alerts by:

- Pulling in supporting facts information from the alert event by modifying structs. These deatails will be used to tell the story of the composite alert in SecurityHub
- Added composite.go to build Composite alert payloads
- Added routing in findings.go to utilize composite.com