### PR TITLE
Fix errors for new vuln binary type and some compliance alerts

### DIFF
--- a/internal/findings/application.go
+++ b/internal/findings/application.go
@@ -81,7 +81,7 @@ func (a App) otherDetails(data types.Data) (*string, map[string]*string) {
 	var id *string
 	switch data.EventType {
 	case "NewExternalClientBadIp", "NewExternalClientConn", "NewExternalServerIp", "NewChildLaunched",
-		"NewExternalServerDNSConn", "NewInternalConnection", "NewBinaryType", "NewExternalServerBadDns":
+		"NewExternalServerDNSConn", "NewInternalConnection", "NewBinaryType", "NewExternalServerBadDns", "NewVulnBinaryType":
 		if len(data.EntityMap.Container) > 0 {
 			image := fmt.Sprintf("%s:%s", data.EntityMap.Container[0].IMAGEREPO, data.EntityMap.Container[0].IMAGETAG)
 			if len(image) > 64 {

--- a/internal/findings/compliance.go
+++ b/internal/findings/compliance.go
@@ -203,6 +203,11 @@ func (c *Compliance) getTypes() []*string {
 	}
 
 	t := fmt.Sprintf("Software and Configuration Checks/Lacework/%s", reason)
+	// If Types contains more than two "/", it will fail to meet ASFF requirements
+	parts := strings.Split(t, "/")
+	if len(parts) > 2 {
+		t = strings.Join(parts[:2], "/") + ":" + strings.Join(parts[2:], ":")
+	}
 	tList = append(tList, aws.String(t))
 	return tList
 }

--- a/internal/findings/mappings.go
+++ b/internal/findings/mappings.go
@@ -35,6 +35,7 @@ func InitMap() (map[string]string, map[string]string) {
 	eventMap["NewErrorDns"] = UnusualNetwork
 	eventMap["NewDnsQueryToCountry"] = TtpInitialAccess
 	eventMap["NewBinaryType"] = TtpDiscovery
+	eventMap["NewVulnBinaryType"] = TtpDiscovery
 	eventMap["NewMachineServerCluster"] = TtpDiscovery
 	eventMap["NewUser"] = TtpDiscovery
 	eventMap["NewPrivilegeEscalation"] = TtpPrivilege


### PR DESCRIPTION
Added support for "NewVulnBinaryType" alerts

Fixed issue with Compliance alerts with more than two "/" characters in a ASFF Type failing due to a violation in required pattern - "^([^/]+)(/[^/]+){0,2}$"